### PR TITLE
greatly simplify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ tmpl({first:'Barbra', last: 'Streisand';});
 
 What is happening?
 ------------------
-Module references like require('*.vash') files will be intercepted during the browserify transform.  Once intercepted, the template is compiled and a new module that exports the complied template function is generated.  Next, the generated module is written to disk and the original require('my-template.vash') is replaced with a require to the generated module containing the compiled template.
+Module references like require('*.vash') files will be intercepted during the browserify transform.  Once intercepted, the template is compiled and a new module that exports the complied template function is generated.
 
-This means templates that are required multiple times will only appear in the bundle once and the vash-runtime is only included once... which is good for business.
+The vash runtime is automatically included one time, the first time a vash file is required.
+
+This means templates that are required multiple times will only appear in the bundle once and the vash runtime is only included once... which is good for business.

--- a/example/entry.js
+++ b/example/entry.js
@@ -1,5 +1,5 @@
 var tmpl = require('./template.vash');
-var vash = require('vash-runtime');
+var vash = require('vash/runtime');
 
 vash.helpers.fullName = function (model){
 	return model.first + ' ' + model.last;

--- a/index.js
+++ b/index.js
@@ -1,120 +1,42 @@
-var tt = require('browserify-transform-tools'),
-	fs = require('fs'),
-	path = require('path'),
-	mkdirp = require('mkdirp'),
-	path = require('path'),
-	resolve = require('resolve'),
-	rerequire = require('re-require'),
-	vash = require('vash');
+var through = require('through');
+var objectAssign = require('object-assign');
 
-vash.config.debug = !(/^prod(uction)?$/i).test(process.env.NODE_ENV);
+module.exports = function vashify (file, opts) {
 
-var counter = 0;
-var lookup = Object.create(null);
-var moduleTemplate = vash.compile(fs.readFileSync(__dirname + '/module.vash').toString());
+	opts = objectAssign({}, {
+		extensions: ['.vash', '.html', '.cshtml'],
+		compiler: null,
+		runtime: 'vash/runtime'
+	}, opts);
 
-var VASH_DIRECTORY = path.dirname(resolve.sync('vash'));
-var VASH_RUNTIME_LOCATION = path.join(VASH_DIRECTORY, 'vash-runtime-all.min.js');
-var VASH_TEMPLATE_REGEX = [
-	/\.vash$/i,
-	/\.aspx$/i
-];
+	// Only require this afterwards to allow the consumer to pass in their
+	// own instance of vash without forcing the local one to be loaded (since
+	// vash is only a devDependency it might not be in the tree).
+	if (!opts.compiler) opts.compiler = require('vash');
 
-mkdirp.sync(__dirname + '/.temp');
+	var vash = opts.compiler;
+	vash.config.debug = !(/^prod(uction)?$/i).test(process.env.NODE_ENV);
 
-function isVashTemplate(fileName){
-	return VASH_TEMPLATE_REGEX.some(function(regex){
-		return regex.test(fileName);
+	var some = opts.extensions.some(function (ext) {
+		return file.indexOf(ext) > -1;
+	});
+
+	// a pipe or something similar appears as this filename.
+	var fileIsLikelyStream = /_stream_[0-9]+\.js/.exec(file);
+
+	if (!some && !fileIsLikelyStream) return through();
+
+	var buffer = '';
+	return through (function (chunk) {
+		buffer += chunk.toString();
+	}, function () {
+		var tpl = vash[opts.helper ? 'compileHelper' : 'compile'](buffer, opts);
+		var linked = tpl.toClientString();
+		var output = ''
+			+ '// compiled with vashify\n'
+			+ 'var vash = require(\'' + opts.runtime + '\');\n'
+			+ 'module.exports = ' + linked + ';\n';
+		this.queue(output);
+		this.queue(null);
 	});
 }
-
-function isVashLibrary(fileName){
-	return (/^vash-runtime$/i).test(fileName);
-}
-
-function postProcessVashTemplate(strJavascript, absoluteFileLocation){
-	var dirName = path.dirname(absoluteFileLocation);
-
-	return rerequire(strJavascript, function(){
-
-		var arg = this.value.arguments[0].value;
-
-		if (!/\.vash$/i.test(arg)) return;
-
-		var fn;
-		var file = path.resolve(dirName, arg); 
-		var strTmpl = fs.readFileSync(file, 'utf-8');
-
-		try {
-			fn = vash.compile(strTmpl);
-		}
-		catch (e){
-			process.stderr.write('Error compiling: ' + file + '\n');
-			throw e;
-		}
-
-		this.value.arguments[0].value = writeCompiledTemplate(fn.toClientString(), file);
-	});
-}
-
-function writeCompiledTemplate(strJavascript, absoluteFileName){
-	var moduleLocation = lookup[absoluteFileName];
-	if (moduleLocation) return moduleLocation;
-
-	var basename = path.basename(absoluteFileName);
-
-	var moduleContents = postProcessVashTemplate(moduleTemplate({
-		vashRuntimeLocation: VASH_RUNTIME_LOCATION.replace(/\\/g, '\\\\'),
-		clientString: strJavascript
-	}), absoluteFileName);
-
-	moduleLocation = lookup[absoluteFileName] = path.join(__dirname,  '.temp', counter++ + '_'+basename + '.js');
-	fs.writeFileSync(path.normalize(moduleLocation), moduleContents);
-
-	return moduleLocation;
-}
-
-function compileVashTemplate(relativeTemplateReference, moduleFile){
-	var templateFileName = relativeTemplateReference.match(/[^\/]*$/)[0];
-	var moduleDirName = path.dirname(moduleFile);
-	var fullTemplateFileName = path.resolve(moduleDirName, relativeTemplateReference);
-
-	var strTmpl;
-	try {
-		strTmpl = fs.readFileSync(fullTemplateFileName);
-	}
-	catch (e){
-		process.stderr.write('Error reading: ' + templateFileName + '\n');
-		throw e;
-	}
-
-	var fn;
-	try {
-		fn = vash.compile(strTmpl.toString());
-	}
-	catch (e){
-		process.stderr.write('Error compiling: ' + templateFileName + '\n');
-		throw e;
-	}
-
-	var moduleLocation = writeCompiledTemplate(fn.toClientString(), fullTemplateFileName);
-	return 'require("'+moduleLocation.replace(/\\/g, '\\\\') + '")';
-}
-
-var makeTransform = tt.makeRequireTransform.bind(tt, 'vashify', {evaluateArguments: true, jsFilesOnly: true});
-var myTransform = makeTransform(function(args, opts, cb) {
-	var arg0 = args[0];
-
-	if (isVashLibrary(arg0)) {
-		return cb(null, 'require("' + VASH_RUNTIME_LOCATION.replace(/\\/g, '\\\\') + '")');
-	}
-	
-	if (isVashTemplate(arg0)) {
-		return cb(null, compileVashTemplate(arg0, opts.file));
-	}
-
-	return cb();
-});
-
-
-module.exports = myTransform;

--- a/module.vash
+++ b/module.vash
@@ -1,2 +1,0 @@
-var vash = require('@html.raw(model.vashRuntimeLocation)');
-module.exports = @html.raw(model.clientString);

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "compile vash templates for use with browserify",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/browserify/bin/cmd.js -t ./index.js ./example/entry.js",
-    "test": "$(test \"$(./node_modules/browserify/bin/cmd.js -t ./index.js ./example/entry.js|node | tr -d '\n')\" = \"Hi Skeet Ulrich.  wow.\") && echo 'PASS' || ! echo 'FAIL'"
+    "start": "browserify-t ./index.js ./example/entry.js",
+    "test": "$(test \"$(browserify -t ./index.js ./example/entry.js|node | tr -d '\n')\" = \"Hi Skeet Ulrich.  wow.\") && echo 'PASS' || ! echo 'FAIL'"
   },
   "repository": {
     "type": "git",
@@ -23,14 +23,12 @@
     "url": "https://github.com/chevett/vashify/issues"
   },
   "homepage": "https://github.com/chevett/vashify",
-  "dependencies": {
-    "browserify-transform-tools": "^1.2.1",
-    "mkdirp": "^0.5.0",
-    "re-require": "0.0.1",
-    "resolve": "^1.0.0",
-    "vash": "^0.7.12-1"
-  },
   "devDependencies": {
-    "browserify": "^6.2.0"
+    "browserify": "^6.2.0",
+    "vash": "^0.10.0"
+  },
+  "dependencies": {
+    "object-assign": "^4.0.1",
+    "through": "^2.3.8"
   }
 }


### PR DESCRIPTION
Browserify reparses transformed files to find requires within. This,
combined with vash's better handling of its runtime in versions > 0.9
means much of this package can be simplified.
